### PR TITLE
Fix multiplication symbols in PQL docs

### DIFF
--- a/docs/pql.md
+++ b/docs/pql.md
@@ -65,9 +65,9 @@ size > 1gb
 
  * `s` - seconds. Does nothing.
  * `m` - minutes. Multiplies the value with 60.
- * `h` - hours. Multiplies the value with 60 * 60.
- * `d` - days. Multiplies the value with 60 * 60 * 24.
- * `w` - weeks. Multiplies the value with 60 * 60 * 24 * 7.
+ * `h` - hours. Multiplies the value with 60 × 60.
+ * `d` - days. Multiplies the value with 60 × 60 × 24.
+ * `w` - weeks. Multiplies the value with 60 × 60 × 24 × 7.
 
 ## Flags
 


### PR DESCRIPTION
In markdown, text surrounded by asterisks is rendered in italics. Currently, the "Duration suffixes" section uses asterisks for showing how the values are multiplied, but the end result is that that some of the symbols are not rendered between the numbers.

This PR replaces the asterisks with actual multiplication signs where applicable.